### PR TITLE
Hide empty footer buttons

### DIFF
--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -272,6 +272,10 @@ export default defineComponent({
   font-size: 3rem;
 }
 
+.modal-footer > .btn:empty {
+  display: none;
+}
+
 .bs-dialog-animated {
   --animation-duration: 0.5s;
   -webkit-animation-duration: 0.5s;


### PR DESCRIPTION
added style that if modal footer button is empty, hide it this enables hiding buttons for the confirm-style modal by specifying empty-string / null as content